### PR TITLE
删除多此一举的 toZeroHost , 修复前缀长度丢失

### DIFF
--- a/src/main/java/com/ghostchu/btn/sparkle/module/analyse/AnalyseService.java
+++ b/src/main/java/com/ghostchu/btn/sparkle/module/analyse/AnalyseService.java
@@ -446,7 +446,7 @@ schedule_interval => INTERVAL '1 hour');
                 .map(ip -> {
                     try {
                         if (ip.getPrefixLength() == null && ip.isIPv6()) {
-                            ip = ip.toPrefixBlock(ipv6ConvertToPrefixLength).toZeroHost();
+                            ip = ip.toPrefixBlock(ipv6ConvertToPrefixLength);
                         }
                     } catch (Exception e) {
                         log.error("Unable to convert {} with prefix block {}.", ip, ipv6ConvertToPrefixLength, e);
@@ -463,7 +463,7 @@ schedule_interval => INTERVAL '1 hour');
             if (!ip.isLocal() && !ip.isLoopback()) {
                 try {
                     if (ip.getPrefixLength() == null && ip.isIPv6()) {
-                        ip = ip.toPrefixBlock(ipv6ConvertToPrefixLength).toZeroHost();
+                        ip = ip.toPrefixBlock(ipv6ConvertToPrefixLength);
                     }
                     dualIPv4v6Tries.add(ip);
                 } catch (Exception e) {


### PR DESCRIPTION
fix https://github.com/PBH-BTN/BTN-Collected-Rules/issues/35

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新特性**
  - 改进了对IPv6地址的处理方式。
  
- **Bug 修复**
  - 修复了在处理IPv6地址时的前缀块转换问题。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->